### PR TITLE
Version 1.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,18 +27,22 @@ requirements:
 test:
   imports:
     - cssselect
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://pythonhosted.org/cssselect/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
   summary: CSS Selectors for Python
   description: |
     Cssselect parses CSS3 Selectors and translate them to XPath 1.0
     expressions. Such expressions can be used in lxml or another XPath engine
     to find the matching elements in an XML or HTML document.
-  doc_url: https://cssselect.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/scrapy/cssselect/blob/master/README.rst
+  doc_url: https://cssselect.readthedocs.io/
   dev_url: https://github.com/scrapy/cssselect
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cssselect" %}
-{% set version = "1.1.0" %}
-{% set sha256 = "dde8c1d4a2c82de6889a3af1c1adbce1a6f3ec08b07a854d873f3f3da92960af" %}
+{% set version = "1.2.0" %}
+{% set sha256 = "a5d17fc420dad4d70ff63a585ad315caf9c5868f750551362b5dbb6e8307c66c" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
     - setuptools
+    - wheel
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cssselect" %}
 {% set version = "1.2.0" %}
-{% set sha256 = "a5d17fc420dad4d70ff63a585ad315caf9c5868f750551362b5dbb6e8307c66c" %}
+{% set sha256 = "666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc" %}
 
 package:
   name: {{ name }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/scrapy/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "cssselect" %}
 {% set version = "1.2.0" %}
-{% set sha256 = "666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc" %}
 
 package:
   name: {{ name }}
@@ -9,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: "666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc"
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - setuptools
     - pip
     - wheel
-
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc"
+  sha256: 666b19839cfaddb9ce9d36bfe4c969132c647b92fc9088c4e23f786b30f1b3dc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python
     - setuptools
+    - pip
     - wheel
 
   run:


### PR DESCRIPTION
cssselect 1.2.0

**Destination channel:** defaults

### Links

- [PKG-4022](https://anaconda.atlassian.net/browse/PKG-4022)
- [Upstream repository](https://github.com/scrapy/cssselect)
- [Upstream changelog/diff](https://github.com/scrapy/cssselect/blob/master/CHANGES)
- Relevant dependency PRs:
  - [PKG-4003](https://anaconda.atlassian.net/browse/PKG-4003)

### Explanation of changes:

- Update to `1.2.0`
- Update build script and source url to link to pypi
- Recipe cleanup
- Linter fixes

[PKG-4022]: https://anaconda.atlassian.net/browse/PKG-4022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-4003]: https://anaconda.atlassian.net/browse/PKG-4003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ